### PR TITLE
Fluxter.Conn.new: Parse port if its a string

### DIFF
--- a/lib/fluxter/conn.ex
+++ b/lib/fluxter/conn.ex
@@ -15,6 +15,12 @@ defmodule Fluxter.Conn do
 
   def new(host, port) when is_list(host) or is_tuple(host) do
     {:ok, addr} = :inet.getaddr(host, :inet)
+    port = case is_binary(port) do
+             true ->
+               {int_port, _} = Integer.parse(port)
+               int_port
+             false -> port
+           end
     header = Packet.header(addr, port)
     %__MODULE__{header: header}
   end


### PR DESCRIPTION
## Background
This was causing an error when using distillery and having the sys.config be environment variables read at runtime.

The error:
```
ArithmeticError) bad argument in arithmetic expression
            (fluxter) lib/fluxter/packet.ex:11: Fluxter.Packet.header/2
            (fluxter) lib/fluxter/conn.ex:18: Fluxter.Conn.new/2
```

## Changes
* Parse `port` if its a binary