### PR TITLE
Drop support for Elixir older than 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   format:
     name: Code linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -31,13 +31,11 @@ jobs:
 
   test:
     name: Test suite
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
         versions:
-          - otp: 18.3
-            elixir: 1.5
           - otp: 23
             elixir: 1.11
 

--- a/lib/fluxter.ex
+++ b/lib/fluxter.ex
@@ -284,7 +284,7 @@ defmodule Fluxter do
     quote unquote: false, location: :keep do
       @behaviour Fluxter
 
-      @pool_size Application.get_env(__MODULE__, :pool_size, 5)
+      @pool_size Application.compile_env(__MODULE__, :pool_size, 5)
       @worker_names Enum.map(0..(@pool_size - 1), &:"#{__MODULE__}-#{&1}")
 
       @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Fluxter.Mixfile do
     [
       app: :fluxter,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.11",
       deps: deps(),
 
       # Hex


### PR DESCRIPTION
I'm suggesting to drop older elixir version for few reasons:

First the tests are running on [Elixir 1.11 ](https://github.com/lexmag/fluxter/pull/36)

Second Elixir team is [only supporting Elixir 1.10 and above](https://hexdocs.pm/elixir/compatibility-and-deprecations.html). Also support of `1.10` will be dropped in 2 months.


And finally I needed to upgrade my projects to Elixir 1.14 but using this library throws warning: 
```
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/fluxter.ex:287: MyApp.Fluxter
```

I compile my projects with `mix compile --warnings-as-errors` and therefore I need to change the use of `Application.get_env` to `Application.compile_env`. However `Application.compile_env` is available [from 1.10 and above](https://hexdocs.pm/elixir/Application.html#compile_env/3) 

