### PR TITLE
Fix compile warning for Elixir 1.14 and newer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   format:
     name: Code linting
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -31,12 +31,12 @@ jobs:
 
   test:
     name: Test suite
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
         versions:
-          - otp: 18.3
+          - otp: 20
             elixir: 1.5
           - otp: 23
             elixir: 1.11

--- a/lib/fluxter.ex
+++ b/lib/fluxter.ex
@@ -281,10 +281,12 @@ defmodule Fluxter do
 
   @doc false
   defmacro __using__(_opts) do
-    quote unquote: false, location: :keep do
+    pool_size = Application.get_env(__CALLER__.module, :pool_size, 5)
+
+    quote bind_quoted: [pool_size: pool_size], location: :keep do
       @behaviour Fluxter
 
-      @pool_size Application.get_env(__MODULE__, :pool_size, 5)
+      @pool_size pool_size
       @worker_names Enum.map(0..(@pool_size - 1), &:"#{__MODULE__}-#{&1}")
 
       @doc false


### PR DESCRIPTION
I'm getting this error when compiling my app : 
```
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/fluxter.ex:287: MyApp.Fluxter
```

I compile my projects with `mix compile --warnings-as-errors`. To keep the compatibility with older Elixir version, I'd suggest to keep `Application.get_env/3` and just move the location that it's called.


BTW I'd rather to make d20518dcb4f26cae09066d83a00242473cf27fb1 in another PR. However it's hard to prove my PR works without changing the CI config as `ubuntu-16 `is not supported in Github Action anymore. ~Also Elixir 1.8 is not available in `ubuntu-20.04`~

let me know if it's ok with you or you'd rather to split this PR to two